### PR TITLE
[EvaluatorChannel] Fix consumer self notifying

### DIFF
--- a/octobot_evaluators/channels/evaluator_channel.pxd
+++ b/octobot_evaluators/channels/evaluator_channel.pxd
@@ -21,6 +21,8 @@ from octobot_channels.producer cimport Producer
 cdef class EvaluatorChannel(Channel):
     cdef public str matrix_id
 
+    cpdef list get_consumer_from_filters(self, dict consumer_filters, EvaluatorChannelConsumer origin_consumer=*)
+
 cdef class EvaluatorChannelConsumer(Consumer):
     pass
 

--- a/octobot_evaluators/channels/evaluator_channel.py
+++ b/octobot_evaluators/channels/evaluator_channel.py
@@ -38,6 +38,17 @@ class EvaluatorChannel(Channel):
         super().__init__()
         self.matrix_id = matrix_id
 
+    def get_consumer_from_filters(self, consumer_filters, origin_consumer=None) -> list:
+        """
+        Returns the instance filtered consumers list except origin_consumer if provided
+        :param consumer_filters: the consumer filters dict
+        :param origin_consumer: the consumer behind the call if any else None
+        :return: the filtered consumer list
+        """
+        return [consumer
+                for consumer in super(EvaluatorChannel, self).get_consumer_from_filters(consumer_filters)
+                if origin_consumer is None or consumer is not origin_consumer]
+
 
 def set_chan(chan, name) -> None:
     chan_name = chan.get_name() if name else name

--- a/octobot_evaluators/channels/evaluators.py
+++ b/octobot_evaluators/channels/evaluators.py
@@ -35,7 +35,8 @@ class EvaluatorsChannelProducer(EvaluatorChannelProducer):
                    exchange_name=CHANNEL_WILDCARD,
                    cryptocurrency=CHANNEL_WILDCARD,
                    symbol=CHANNEL_WILDCARD,
-                   time_frame=CHANNEL_WILDCARD):
+                   time_frame=CHANNEL_WILDCARD,
+                   origin_consumer=None):
         for consumer in self.channel.get_filtered_consumers(matrix_id=matrix_id,
                                                             data=data,
                                                             evaluator_name=evaluator_name,
@@ -43,7 +44,8 @@ class EvaluatorsChannelProducer(EvaluatorChannelProducer):
                                                             exchange_name=exchange_name,
                                                             cryptocurrency=cryptocurrency,
                                                             symbol=symbol,
-                                                            time_frame=time_frame):
+                                                            time_frame=time_frame,
+                                                            origin_consumer=origin_consumer):
             await consumer.queue.put({
                 "matrix_id": matrix_id,
                 "evaluator_name": evaluator_name,
@@ -101,7 +103,8 @@ class EvaluatorsChannel(EvaluatorChannel):
                                exchange_name=CHANNEL_WILDCARD,
                                cryptocurrency=CHANNEL_WILDCARD,
                                symbol=CHANNEL_WILDCARD,
-                               time_frame=CHANNEL_WILDCARD):
+                               time_frame=CHANNEL_WILDCARD,
+                               origin_consumer=None):
         return self.get_consumer_from_filters({
             self.MATRIX_ID_KEY: matrix_id,
             self.EVALUATOR_NAME_KEY: evaluator_name,
@@ -110,7 +113,8 @@ class EvaluatorsChannel(EvaluatorChannel):
             self.CRYPTOCURRENCY_KEY: cryptocurrency,
             self.SYMBOL_KEY: symbol,
             self.TIME_FRAME_KEY: time_frame,
-        })
+        },
+            origin_consumer=origin_consumer)
 
     async def _add_new_consumer_and_run(self, consumer,
                                         matrix_id=CHANNEL_WILDCARD,

--- a/octobot_evaluators/channels/matrix.py
+++ b/octobot_evaluators/channels/matrix.py
@@ -46,14 +46,16 @@ class MatrixChannelProducer(EvaluatorChannelProducer):
                    exchange_name=None,
                    cryptocurrency=CHANNEL_WILDCARD,
                    symbol=CHANNEL_WILDCARD,
-                   time_frame=None):
+                   time_frame=None,
+                   origin_consumer=None):
         for consumer in self.channel.get_filtered_consumers(matrix_id=matrix_id,
                                                             cryptocurrency=cryptocurrency,
                                                             symbol=symbol,
                                                             time_frame=time_frame,
                                                             evaluator_type=evaluator_type,
                                                             evaluator_name=evaluator_name,
-                                                            exchange_name=exchange_name):
+                                                            exchange_name=exchange_name,
+                                                            origin_consumer=origin_consumer):
             await consumer.queue.put({
                 "matrix_id": matrix_id,
                 "evaluator_name": evaluator_name,
@@ -75,7 +77,8 @@ class MatrixChannelProducer(EvaluatorChannelProducer):
                              exchange_name: str = None,
                              cryptocurrency: str = None,
                              symbol: str = None,
-                             time_frame=None):
+                             time_frame=None,
+                             origin_consumer=None):
         set_tentacle_value(
             matrix_id=matrix_id,
             tentacle_type=eval_note_type,
@@ -98,7 +101,8 @@ class MatrixChannelProducer(EvaluatorChannelProducer):
                         exchange_name=exchange_name,
                         cryptocurrency=cryptocurrency,
                         symbol=symbol,
-                        time_frame=time_frame)
+                        time_frame=time_frame,
+                        origin_consumer=origin_consumer)
 
 
 class MatrixChannel(EvaluatorChannel):
@@ -147,7 +151,8 @@ class MatrixChannel(EvaluatorChannel):
                                evaluator_type=CHANNEL_WILDCARD,
                                time_frame=CHANNEL_WILDCARD,
                                evaluator_name=CHANNEL_WILDCARD,
-                               exchange_name=CHANNEL_WILDCARD):
+                               exchange_name=CHANNEL_WILDCARD,
+                               origin_consumer=None):
         return self.get_consumer_from_filters({
             self.MATRIX_ID_KEY: matrix_id,
             self.CRYPTOCURRENCY_KEY: cryptocurrency,
@@ -156,7 +161,8 @@ class MatrixChannel(EvaluatorChannel):
             self.EVALUATOR_TYPE_KEY: evaluator_type,
             self.EVALUATOR_NAME_KEY: evaluator_name,
             self.EXCHANGE_NAME_KEY: exchange_name
-        })
+        },
+            origin_consumer=origin_consumer)
 
     async def _add_new_consumer_and_run(self, consumer,
                                         matrix_id=CHANNEL_WILDCARD,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 # Setup requirements
-cython==0.29.16
-numpy==1.18.2
+cython==0.29.17
+numpy==1.18.3
 
 # Drakkar-Software requirements
-OctoBot-Channels>=1.3.24, <1.4
-OctoBot-Commons>=1.3.10, <1.4
-OctoBot-Tentacles-Manager>=2.0.2, <2.1
+OctoBot-Channels>=1.3.25, <1.4
+OctoBot-Commons>=1.3.12, <1.4
+OctoBot-Tentacles-Manager>=2.0.3, <2.1
 
 # Cryptocurrency trading
 tulipy==0.4.0

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ import os
 
 from setuptools import dist
 
-dist.Distribution().fetch_build_eggs(['Cython>=0.29.16', 'numpy>=1.18.2'])
+dist.Distribution().fetch_build_eggs(['Cython>=0.29.17', 'numpy>=1.18.3'])
 
 import numpy as np
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -13,3 +13,14 @@
 #
 #  You should have received a copy of the GNU Lesser General Public
 #  License along with this library.
+import pytest
+
+from octobot_evaluators.api.evaluators import create_matrix
+from octobot_evaluators.matrices.matrices import Matrices
+
+
+@pytest.yield_fixture()
+async def matrix_id():
+    created_matrix_id = create_matrix()
+    yield created_matrix_id
+    Matrices.instance().del_matrix(created_matrix_id)

--- a/tests/channels/test_evaluator_channel.py
+++ b/tests/channels/test_evaluator_channel.py
@@ -1,0 +1,50 @@
+#  Drakkar-Software OctoBot-Evaluators
+#  Copyright (c) Drakkar-Software, All rights reserved.
+#
+#  This library is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU Lesser General Public
+#  License as published by the Free Software Foundation; either
+#  version 3.0 of the License, or (at your option) any later version.
+#
+#  This library is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#  Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public
+#  License along with this library.
+import pytest
+
+from octobot_channels.util.channel_creator import create_channel_instance
+from octobot_evaluators.api.initialization import del_evaluator_channels
+from octobot_evaluators.channels.evaluator_channel import get_chan, set_chan, EvaluatorChannel
+
+from tests import matrix_id
+
+EVALUATOR_CHANNEL_NAME = "Evaluator"
+
+
+async def evaluator_callback():
+    pass
+
+
+@pytest.fixture()
+async def evaluator_channel(matrix_id):
+    del_evaluator_channels(matrix_id)
+    await create_channel_instance(EvaluatorChannel, set_chan, matrix_id=matrix_id)
+    return matrix_id
+
+
+@pytest.mark.asyncio
+async def test_evaluator_channel_get_consumer_from_filters(evaluator_channel):
+    consumer_1 = await get_chan(EVALUATOR_CHANNEL_NAME, evaluator_channel).new_consumer(evaluator_callback)
+    consumer_2 = await get_chan(EVALUATOR_CHANNEL_NAME, evaluator_channel).new_consumer(evaluator_callback)
+    consumer_3 = await get_chan(EVALUATOR_CHANNEL_NAME, evaluator_channel).new_consumer(evaluator_callback)
+    assert get_chan(EVALUATOR_CHANNEL_NAME, evaluator_channel) \
+               .get_consumer_from_filters({}) == [consumer_1, consumer_2, consumer_3]
+    assert get_chan(EVALUATOR_CHANNEL_NAME, evaluator_channel) \
+               .get_consumer_from_filters({}, origin_consumer=consumer_2) == [consumer_1, consumer_3]
+    assert get_chan(EVALUATOR_CHANNEL_NAME, evaluator_channel) \
+               .get_consumer_from_filters({}, origin_consumer=consumer_1) == [consumer_2, consumer_3]
+    assert get_chan(EVALUATOR_CHANNEL_NAME, evaluator_channel) \
+               .get_consumer_from_filters({}, origin_consumer=consumer_3) == [consumer_1, consumer_2]


### PR DESCRIPTION
Now when sending a matrix notification if origin_consumer is provided, the origin_consumer wont be triggered.